### PR TITLE
fix: CLIN-2323 complex donors queries

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -13,7 +13,7 @@ import arrangerRoutesHandler from "./controllers/arrangerRoutesHandler.js";
 import transcriptsReportHandler from "./controllers/transcriptsReportHandler.js";
 import { sendForbidden } from "./httpUtils.js";
 import { VARIANTS_READ_PERMISSION_ENFORCER, HPO_READ_PERMISSION_ENFORCER } from "./permissionsUtils.js";
-//import variantDonorsHandler from "./controllers/variantDonorsHandler.js"
+import variantDonorsHandler from "./controllers/variantDonorsHandler.js"
 import booleanFilterMiddleware from './middlewares/booleanFilterMiddleware.js'
 
 const app = express();
@@ -93,7 +93,7 @@ app.all("*", arrangerRoutesHandler);
 
 app.post("*", keycloak.protect(), arrangerGqlSecurityHandler);
 
-//app.use(variantDonorsHandler) replaced with beforeES/nestedDonors + afterES/variantDonors
+app.use(variantDonorsHandler)
 
 app.use(booleanFilterMiddleware)
 

--- a/app/middlewares/afterES/variantDonors.js
+++ b/app/middlewares/afterES/variantDonors.js
@@ -4,9 +4,12 @@
 export default function (_, hits) {
     if (hits?.hits) {
         hits.hits = hits.hits?.map((hit) => {
-            const innerHitsDonors = hit?.inner_hits?.donors?.hits?.hits?.map((h)=> h._source)
-            if (innerHitsDonors) {
-                hit._source.donors = structuredClone(innerHitsDonors);
+            if (hit?.inner_hits) {
+                const innerHitsDonors = hit?.inner_hits?.donors?.hits?.hits?.map((h)=> h._source)
+                // don't replace donors if already exist for complex nested queries
+                if (innerHitsDonors && innerHitsDonors.length > 0 && !hit._source.donors) {
+                    hit._source.donors = structuredClone(innerHitsDonors);
+                }
                 delete hit.inner_hits;
             }
             return hit;

--- a/app/middlewares/beforeES/nestedDonors.js
+++ b/app/middlewares/beforeES/nestedDonors.js
@@ -28,7 +28,7 @@ const addInnerHitsDonors = (body) => {
         }
         return null;
     }
-    addInnerHitsDonorsPath(newBody);
+    addInnerHitsDonorsPath(newBody.query);
      // keep original body for complex nested queries
     return countOfNestedDonors === 1 ? newBody : body;
 }

--- a/app/middlewares/beforeES/nestedDonors.js
+++ b/app/middlewares/beforeES/nestedDonors.js
@@ -10,26 +10,27 @@ const addInnerHitsDonors = (body) => {
             "donors"
         ]
     }
+
+    let countOfNestedDonors = 0;
     
     const addInnerHitsDonorsPath = (obj) => {
         for (var key in obj) {
             if (key === 'path' && obj[key] === 'donors') {
+                countOfNestedDonors ++;
                 return obj.inner_hits = {
                     _source: [
                       "donors.*"
                     ]
                   }
             } else if (typeof obj[key] === 'object') {
-                const result = addInnerHitsDonorsPath(obj[key]);
-                if (result !== null) {
-                    return result;
-                }
+                addInnerHitsDonorsPath(obj[key]);
             }
         }
         return null;
     }
     addInnerHitsDonorsPath(newBody);
-    return newBody;
+     // keep original body for complex nested queries
+    return countOfNestedDonors === 1 ? newBody : body;
 }
 
 export default function (body) {
@@ -37,7 +38,7 @@ export default function (body) {
     const analysis_id = findSqonValueInQuery(body.query, DONORS_ANALYSIS_SERVICE_REQUEST_ID)
 
     if(patient_id || analysis_id) {
-        body = addInnerHitsDonors(body)
+       body = addInnerHitsDonors(body)
     }
 
     // console.log('[nestedDonors]', JSON.stringify(body))

--- a/test/nestedDonors.spec.js
+++ b/test/nestedDonors.spec.js
@@ -135,4 +135,95 @@ describe("nestedDonors", () => {
     }
     expect(nestedDonors(query)).to.eql(query)
   });
+  it(`Should not add inner_hits if multiple nested donors ES query`, () => {
+    const common = {
+        bool: {
+            must: [
+                {
+                    terms: {
+                        "donors.patient_id": [
+                            "508428"
+                        ],
+                        boost: 0
+                    }
+                },
+                {
+                    terms: {
+                        "donors.analysis_service_request_id": [
+                            "508427"
+                        ],
+                        boost: 0
+                    }
+                }
+            ]
+        }
+    }
+    const query = {
+        query: {
+            bool: {
+                must: [
+                    {
+                        bool: {
+                            must: [
+                                {
+                                    nested: {
+                                        path: "donors",
+                                        query: common
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        bool: {
+                            must: [
+                                {
+                                    nested: {
+                                        path: "donors",
+                                        query: common
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                ]
+            }
+        }
+    }
+
+    const expected = {
+        query: {
+            bool: {
+                must: [
+                    {
+                        bool: {
+                            must: [
+                                {
+                                    nested: {
+                                        path: "donors",
+                                        query: common
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        bool: {
+                            must: [
+                                {
+                                    nested: {
+                                        path: "donors",
+                                        query: common
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                ]
+            }
+        }
+    }
+
+    expect(nestedDonors(query)).to.eql(expected)
+  });
 });

--- a/test/variantDonors.spec.js
+++ b/test/variantDonors.spec.js
@@ -83,4 +83,74 @@ describe("variantDonors", () => {
     };
     expect(variantDonors(null, hits)).to.eql(hits)
   });
+
+  it(`Should ignore and delete inner_hits if donors already exist`, () => {
+    const hits ={
+        total: {
+            value: 10000,
+        },
+        hits: [
+            {
+                _source: {
+                    variant_type: [
+                        "germline"
+                    ],
+                    locus_id_1: "11-72583396-G-A",
+                    hash: "849b437a6855bade94689c61539e5ee03b418478",
+                    donors: [
+                        {
+                            batch_id: "batch1",
+                            variant_type: "germline",
+                            analysis_service_request_id: "barrr",
+                            patient_id: "fooo",
+                        }
+                    ]
+                },
+                inner_hits: {
+                    donors: {
+                        hits: {
+                            hits: [
+                                {
+                                    _source: {
+                                        batch_id: "201106_A00516_0169_AHFM3HDSXY",
+                                        variant_type: "germline",
+                                        analysis_service_request_id: "508427",
+                                        patient_id: "508428",
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        ]
+    };
+
+    const expected = {
+        total: {
+            value: 10000,
+        },
+        hits: [
+            {
+                _source: {
+                    variant_type: [
+                        "germline"
+                    ],
+                    locus_id_1: "11-72583396-G-A",
+                    hash: "849b437a6855bade94689c61539e5ee03b418478",
+                    donors: [
+                        {
+                            batch_id: "batch1",
+                            variant_type: "germline",
+                            analysis_service_request_id: "barrr",
+                            patient_id: "fooo",
+                        }
+                    ]
+                },
+            }
+        ]
+    };
+       
+    expect(variantDonors(null, hits)).to.eql(expected)
+  });
 });


### PR DESCRIPTION
- [x] enable back `variantDonorsHandler.js`
- [x] ignore `inner_hits` for complex nested donors queries
- [x] add unit tests